### PR TITLE
Add options for loading tiles via AJAX and custom AJAX request headers

### DIFF
--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -142,7 +142,6 @@ function BookReader() {
 
     // Allow images to be loaded with AJAX
     this.loadWithAjax = false;
-    this.ajaxHeaders = {};
 
     return this;
 };
@@ -410,15 +409,16 @@ BookReader.prototype.setClickHandler2UP = function( element, data, handler) {
 
 // loadImage()
 //______________________________________________________________________________
-BookReader.prototype.loadImage = function(src, img) {
+BookReader.prototype.loadImage = function(src, index, img) {
     if (this.loadWithAjax) {
         var xhr = new XMLHttpRequest();
         xhr.open('GET', src);
         xhr.responseType = "arraybuffer";
-        if (this.ajaxHeaders) {
-            for (var headerName in this.ajaxHeaders) {
-                if (this.ajaxHeaders.hasOwnProperty(headerName) && this.ajaxHeaders[headerName]) {
-                    xhr.setRequestHeader(headerName, this.ajaxHeaders[headerName]);
+        if (typeof(this.getAjaxHeaders) !== 'undefined') {
+            var headers = this.getAjaxHeaders(index);
+            for (var headerName in headers) {
+                if (headers.hasOwnProperty(headerName) && headers[headerName]) {
+                    xhr.setRequestHeader(headerName, headers[headerName]);
                 }
             }
         }
@@ -554,8 +554,7 @@ BookReader.prototype.drawLeafsOnePage = function() {
             $(img).css('width', width+'px');
             $(img).css('height', height+'px');
             $(div).append(img);
-            this.loadImage(this._getPageURI(index, this.reduce, 0), img);
-
+            this.loadImage(this._getPageURI(index, this.reduce, 0), index, img);
         } else {
             //console.log("not displaying " + indicesToDisplay[i] + ' score=' + jQuery.inArray(indicesToDisplay[i], this.displayedIndices));            
         }
@@ -755,7 +754,8 @@ BookReader.prototype.drawLeafsThumbnail = function( seekIndex ) {
                     .css({'width': leafWidth+'px', 'height': leafHeight+'px' })
                     .addClass('BRlazyload')
                     // Store the URL of the image that will replace this one
-                    .data('srcURL',  this._getPageURI(leaf, thumbReduce));
+                    .data('srcURL', this._getPageURI(leaf, thumbReduce))
+                    .data('index', leaf);
                 $(link).append(img);
                 //console.log('displaying thumbnail: ' + leaf);
             }   
@@ -880,7 +880,7 @@ BookReader.prototype.lazyLoadImage = function (dummyImage) {
         });
                  
     // replace with the new img
-    this.loadImage($(dummyImage).data('srcURL'), img);
+    this.loadImage($(dummyImage).data('srcURL'), $(dummyImage).data('index'), img);
     $(dummyImage).before(img).remove();
     
     img = null; // tidy up closure
@@ -2554,7 +2554,7 @@ BookReader.prototype.prefetchImg = function(index) {
                 'background-color': '#efefef'
             });
         }
-        this.loadImage(pageURI, img);
+        this.loadImage(pageURI, index, img);
         img.uri = pageURI; // browser may rewrite src so we stash raw URI here
         this.prefetchedImgs[index] = img;
     }


### PR DESCRIPTION
## JIRA Ticket

Part of: 
[ISLANDORA-2100](https://jira.duraspace.org/browse/ISLANDORA-2100)

Upstream PR here: 
https://github.com/internetarchive/bookreader/pull/59

I know we haven't had much luck in the past getting things merged upstream, but I wanted to try.

## What does this Pull Request do?

This PR is based in spirit on https://github.com/openseadragon/openseadragon/pull/1055. It adds the option to load book pages using AJAX and sending custom request headers. This is useful if you have book pages that need authentication to be served that can be sent with the headers. This feature is very useful when using token-based authentication.

When the option not set then tiles should load as they did before.

## What's new?

### property: `loadWithAjax` (Boolean)
When this option is set on the `BookReader` all of the images are loaded in with AJAX.

### function: `getAjaxHeaders(index)`
When this function is provided on the `BookReader` it will be called with the index of the page and returns a  `String -> String` mapping of headers to be sent with the book page. This allows us to send different headers for every page if desired.

## How should this be tested?

For code review, be aware that there are 3 commits here. Two are just code style cleanup. One cleans the whitespace at the end of lines and the other fixes some spelling errors in the source. These have already been cleaned up upstream. The real meat of this PR is https://github.com/jonathangreen/internet_archive_bookreader/commit/cb61e49051ab904788ac19676826d2dca7510f85.

There is a forthcoming PR to the [Islandora IA Bookreader](https://github.com/Islandora/islandora_internet_archive_bookreader) module as part of [ISLANDORA-2100](https://jira.duraspace.org/browse/ISLANDORA-2100) that will enable this option though the UI for testing.

It can also be tested by manually setting the options as described above.

* Make sure that books continue to load as before with `loadWithAjax` set to `false`.
* Make sure books load properly with `loadWithAjax` set to `true`.
* Make sure loads send the correct headers when using `loadWithAjax` with `ajaxHeaders` set.

## Additional Notes:

Setting the `loadWithAjax` option will limit browser support to IE 10+ due to the use of responseType = 'arraybuffer' and [createObjectURL](http://caniuse.com/#feat=bloburls). However if this option isn't used, then the behaviour is the same as it was before. 

## Interested parties
@qadan @Islandora/7-x-1-x-committers