### PR TITLE
Add epmty space in search results baloon.

### DIFF
--- a/BookReader/BookReader.js
+++ b/BookReader/BookReader.js
@@ -3480,7 +3480,7 @@ BookReader.prototype.addSearchResult = function(queryString, pageIndex) {
     queryString = queryString.replace(re, '<a href="#" onclick="br.jumpToIndex('+pageIndex+'); return false;">$1</a>')
 
     var marker = $('<div class="search" style="top:'+(-$('#BRcontainer').height())+'px; left:' + percentThrough + ';" title="' + uiStringSearch + '"><div class="query">'
-        + queryString + '<span>' + uiStringPage + ' ' + pageNumber + '</span></div>')
+        + queryString + ' ' + '<span>' + uiStringPage + ' ' + pageNumber + '</span></div>')
     .data({'self': this, 'pageIndex': pageIndex })
     .appendTo('#BRnavline').bt({
         contentSelector: '$(this).find(".query")',


### PR DESCRIPTION
Divide founded text string and page info.

While testing IA book reader I sow that in a search results balloon founded text string and page info are not divided so added an empty space between to divide it. It is a small aesthetic but functional add.

Tested this also while testing PR#127.

Before
![before](https://user-images.githubusercontent.com/16822119/48895986-c846ba80-ee46-11e8-9a59-c31bf9fde166.png)

After
![added-space](https://user-images.githubusercontent.com/16822119/48895753-24f5a580-ee46-11e8-88a6-dc35f7fe1fe0.png)
